### PR TITLE
Patch on distribution_source_identifier.xml

### DIFF
--- a/dd_data_dictionary.xml.xsl
+++ b/dd_data_dictionary.xml.xsl
@@ -142,16 +142,10 @@ DEBUG: 	  result="<xsl:value-of select="$result"/>"</xsl:message>
 							</xsl:choose>
 							<!-- Replicate DOCUMENTATION as an attribute-->
 							<xsl:attribute name="documentation"><xsl:value-of select="xs:annotation/xs:documentation"/></xsl:attribute>
-							<!-- Replicate LIFECYCLE information as an attribute-->
-							<xsl:attribute name="lifecycle_status"><xsl:value-of select="xs:annotation/xs:appinfo/lifecycle_status"/></xsl:attribute>
-							<xsl:attribute name="lifecycle_version"><xsl:value-of select="xs:annotation/xs:appinfo/lifecycle_version"/></xsl:attribute>
-							<xsl:attribute name="lifecycle_last_change"><xsl:value-of select="xs:annotation/xs:appinfo/lifecycle_last_change"/></xsl:attribute>
-							<xsl:if test="xs:annotation/xs:appinfo/specific_validation_rules">
-								<xsl:attribute name="specific_validation_rules"><xsl:value-of select="xs:annotation/xs:appinfo/specific_validation_rules"/></xsl:attribute>
-							</xsl:if>
-							<xsl:if test="xs:annotation/xs:appinfo/url">
-								<xsl:attribute name="url"><xsl:value-of select="xs:annotation/xs:appinfo/url"/></xsl:attribute>
-							</xsl:if>
+							<xsl:for-each select="xs:annotation/xs:appinfo/*">
+								<!-- Generic method for declaring all appinfo as attributes-->
+								<xsl:attribute name="{name(.)}"><xsl:value-of select="."/></xsl:attribute>
+						    </xsl:for-each>
 							<!-- Indicate whether the IDS is purely constant or contains dynamic quantities -->							
 							<xsl:choose>
 								<xsl:when test="*/*/xs:element[@ref='time']">

--- a/docs/sphinx_dd_extension/autodoc.py
+++ b/docs/sphinx_dd_extension/autodoc.py
@@ -323,7 +323,7 @@ def field2rst(
     if "change_nbc_description" in field.keys():
         change_nbc_description = field.get("change_nbc_description")
         change_nbc_version = field.get("change_nbc_version")
-        renames = ("aos_renamed", "leaf_renamed", "structure_renamed")
+        renames = ("aos_renamed", "leaf_renamed", "structure_renamed", "ids_renamed")
         if change_nbc_description in renames:
             result.append(f".. versionchanged:: {change_nbc_version}")
             result.append(f"  Renamed from ``{field.get('change_nbc_previous_name')}``")

--- a/schemas/utilities/distribution_source_identifier.xml
+++ b/schemas/utilities/distribution_source_identifier.xml
@@ -13,23 +13,23 @@ Translation table for Heating and Current Drive (HCD) distsource types, i.e. typ
 <int name="nuclear"                    description="Source from nuclear reaction (reaction type unspecified)"                  >100</int>
 
 <int name="H_H_to_D_positron_nu"       description="Source from nuclear reaction: H+H->D+positron+neutrino"                    >101</int>
-<int name="H_D_to_3He_gamma"   alias="H_D_to_He3_gamma"        description="Source from nuclear reaction: H+D->3He+gamma"                              >102</int>
-<int name="H_T_to_3He_n" alias="H_T_to_He3_n"    description="Source from nuclear reaction: H+T->3He+neutron"                            >103</int>
-<int name="H_3He_to_4He_positron_nu" alias="H_He3_to_He4_positron_nu"  description="Source from nuclear reaction: H+3He->4He+positron+neutrino"                >104</int>
+<int name="H_D_to_He3_gamma"        description="Source from nuclear reaction: H+D->3He+gamma"                              >102</int>
+<int name="H_T_to_He3_n"    description="Source from nuclear reaction: H+T->3He+neutron"                            >103</int>
+<int name="H_He3_to_He4_positron_nu"  description="Source from nuclear reaction: H+3He->4He+positron+neutrino"                >104</int>
 
 <int name="D_D_to_T_H"                 description="Source from nuclear reaction: D+D->T+H"                                    >105</int>
-<int name="D_D_to_3He_n" alias="D_D_to_He3_n"     description="Source from nuclear reaction: D+D->3He+neutron"                            >106</int>
-<int name="D_T_to_4He_n" alias="D_T_to_He4_n"              description="Source from nuclear reaction: T+D->4He+neutron"                            >107</int>
-<int name="D_3He_to_4He_H" alias="D_He3_to_He4_H"            description="Source from nuclear reaction: 3He+D->4He+H"                                >108</int>
+<int name="D_D_to_He3_n"     description="Source from nuclear reaction: D+D->3He+neutron"                            >106</int>
+<int name="D_T_to_He4_n"              description="Source from nuclear reaction: T+D->4He+neutron"                            >107</int>
+<int name="D_He3_to_He4_H"            description="Source from nuclear reaction: 3He+D->4He+H"                                >108</int>
 
-<int name="T_T_to_4He_n_n" alias="T_T_to_He4_n_n"            description="Source from nuclear reaction: T+T->4He+neutron+neutron"                    >109</int>
-<int name="T_3He_to_4He_H_n" alias="T_He3_to_He4_H_n"          description="Source from nuclear reaction: 3He+T->4He+H+neutron"                        >110</int>
+<int name="T_T_to_He4_n_n"            description="Source from nuclear reaction: T+T->4He+neutron+neutron"                    >109</int>
+<int name="T_He3_to_He4_H_n"          description="Source from nuclear reaction: 3He+T->4He+H+neutron"                        >110</int>
 
-<int name="3He_3He_to_4He_H_H"  alias="He3_He3_to_He4_H_H"       description="Source from nuclear reaction: 3He+3He->4He+neutron+neutron"                >111</int>
-<int name="3He_4He_to_7Be_gamma" alias="He3_He4_to_Be7_gamma"      description="Source from nuclear reaction: 3He+4He->7Be+gamma"                          >112</int>
+<int name="He3_He3_to_He4_H_H"       description="Source from nuclear reaction: 3He+3He->4He+neutron+neutron"                >111</int>
+<int names="He3_He4_to_Be7_gamma"      description="Source from nuclear reaction: 3He+4He->7Be+gamma"                          >112</int>
 
-<int name="6Li_n_to_4He_T"  alias="Li6_n_to_He4_T"           description="Source from nuclear reaction: 6Li+n->4He+T"                                >113</int>
-<int name="7Li_n_to_4He_T_n"  alias="Li7_n_to_He4_T_n"         description="Source from nuclear reaction: 7Li+n->4He+T+n"                              >114</int>
+<int names="Li6_n_to_He4_T"           description="Source from nuclear reaction: 6Li+n->4He+T"                                >113</int>
+<int name="Li7_n_to_He4_T_n"         description="Source from nuclear reaction: 7Li+n->4He+T+n"                              >114</int>
  
 <int name="runaway"                    description="Source from runaway processes"                                             >1000</int>
 


### PR DESCRIPTION
In order to move forward with the installation of the DD blancket, I need these identifiers as they were before, without alias. 
It seems that these aliases are not taken into account: only the names are that triggers an error when compiling. Indeed, a define in header file can not begins with a digit.



<!-- readthedocs-preview imas-data-dictionary start -->
----
📚 Documentation preview 📚: https://imas-data-dictionary--1.org.readthedocs.build/en/1/

<!-- readthedocs-preview imas-data-dictionary end -->